### PR TITLE
Update hapi and node versions.

### DIFF
--- a/hapi_all.yml
+++ b/hapi_all.yml
@@ -1,6 +1,6 @@
 env:
-  - HAPI_VERSION="19"
   - HAPI_VERSION="20"
+  - HAPI_VERSION="21"
 
 install:
   - "npm install"

--- a/node_js.yml
+++ b/node_js.yml
@@ -1,8 +1,8 @@
 language: node_js
 
 node_js:
-  - "12"
-  - "14"
+  - "16"
+  - "18"
   - "node"
 
 jobs:


### PR DESCRIPTION
 Add hapi 21 and drop 19 (since it's deprecated). Drop node 12 and 14, add 16 and 18, leaving `node` in place.